### PR TITLE
fix(workflows): update visual-regression.yml for monorepo structure

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -4,19 +4,19 @@ on:
   push:
     branches: [main, develop]
     paths:
-      - 'src/**'
+      - 'packages/*/src/**'
       - 'stories/**'
       - '.storybook/**'
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
   pull_request:
     branches: [main, develop]
     paths:
-      - 'src/**'
+      - 'packages/*/src/**'
       - 'stories/**'
       - '.storybook/**'
       - 'package.json'
-      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
 
 # Prevent concurrent runs on the same PR
 concurrency:
@@ -27,7 +27,6 @@ jobs:
   visual-tests:
     name: Visual Regression Tests
     runs-on: ubuntu-latest
-    continue-on-error: true  # TODO: Fix for monorepo structure - Storybook and visual testing need updates
     timeout-minutes: 30
 
     steps:


### PR DESCRIPTION
## Summary

Updates the visual-regression.yml workflow for the monorepo structure.

## Changes

- Updated path triggers from `src/**` to `packages/*/src/**`
- Changed lock file reference from `package-lock.json` to `pnpm-lock.yaml`
- Removed `continue-on-error: true` flag from visual-tests job
- Workflow now properly monitors monorepo package changes

## Related PRs

- #22 (quality-gates.yml - merged)
- #23 (ci.yml - pending review)

## Testing

Workflow will run automatically when PR is created/updated with changes to:
- `packages/*/src/**`
- `stories/**`
- `.storybook/**`
- `package.json`
- `pnpm-lock.yaml`