### PR TITLE
fix(ci): enable Component Tests and Cross-Browser Testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,6 @@ jobs:
     name: Component Tests
     runs-on: ubuntu-latest
     needs: [build] # Run after build succeeds
-    continue-on-error: true # Make optional to unblock CI while fixing Cypress issues
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -253,7 +252,6 @@ jobs:
     name: Cross-Browser Testing
     runs-on: ubuntu-latest
     needs: [build]
-    continue-on-error: true # Make optional to unblock CI while fixing port conflicts
     timeout-minutes: 30
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Enable Component Tests and Cross-Browser Testing in CI pipeline by removing `continue-on-error` flags.

**Changes:**
- Remove `continue-on-error: true` from Component Tests job (Cypress)
- Remove `continue-on-error: true` from Cross-Browser Testing job (Playwright)
- Make both jobs required for CI success

**Why:**
These jobs were previously made optional to unblock CI while fixing issues. Now that we're systematically addressing CI health, we need to re-enable them to ensure they actually pass and catch issues.

**Testing:**
- All 2900+ tests pass locally
- Pre-push validation passed
- Will monitor CI run to verify jobs execute and pass

**Related:**
- Part of Phase 1: Fix non-critical CI processes
- Relates to moving 27 JSDOM-limited tests to Cypress/Playwright

## Test Plan

- [x] Local tests pass
- [ ] Component Tests job passes in CI
- [ ] Cross-Browser Testing job passes in CI
- [ ] All other CI jobs still pass

Generated with [Claude Code](https://claude.com/claude-code)